### PR TITLE
250106 fix: Redis 의존성 주입 및 비동기 처리 개선

### DIFF
--- a/apis/meetings.py
+++ b/apis/meetings.py
@@ -1,6 +1,6 @@
 from typing import List
-from fastapi import APIRouter, HTTPException, status
-from redis import Redis
+from fastapi import APIRouter, HTTPException, status, Depends
+from redis.asyncio import Redis
 
 from crud.meetings import (
     add_to_meeting_room,
@@ -8,6 +8,7 @@ from crud.meetings import (
     get_all_meeting_rooms,
 )
 from request_schemas.meetings import MeetingRoomCreate, RoomJoin, RoomLeave
+from core.databases import get_redis
 
 meetings_router = APIRouter(prefix="/meetingroom")
 
@@ -15,7 +16,9 @@ meetings_router = APIRouter(prefix="/meetingroom")
 @meetings_router.post(
     "/create", response_model=dict, status_code=status.HTTP_201_CREATED
 )
-async def create_meeting_room(request: MeetingRoomCreate):
+async def create_meeting_room(
+    request: MeetingRoomCreate, redis: Redis = Depends(get_redis)
+):
     """
     새로운 미팅룸을 Redis에 생성하는 엔드포인트입니다.
 
@@ -23,15 +26,19 @@ async def create_meeting_room(request: MeetingRoomCreate):
 
     Args:
         request (MeetingRoomCreate): 미팅룸 생성 요청 정보
+        redis (Redis): Redis 클라이언트 인스턴스
 
     Returns:
         dict: 성공 메시지
     """
     try:
-        await add_to_meeting_room(request.room_id, request.title, request.client_id)
+        await add_to_meeting_room(
+            redis, request.room_id, request.title, request.client_id
+        )
         return {"message": "미팅룸 생성 성공"}
 
     except Exception as e:
+        print(e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Redis에서 미팅룸 생성 중 오류가 발생했습니다.",
@@ -39,19 +46,23 @@ async def create_meeting_room(request: MeetingRoomCreate):
 
 
 @meetings_router.get("/list", response_model=List[dict])
-async def get_meeting_rooms():
+async def get_meeting_rooms(redis: Redis = Depends(get_redis)):
     """
     Redis에서 모든 미팅룸의 정보를 조회하는 엔드포인트입니다.
 
     URL: /meetingroom/list
 
+    Args:
+        redis (Redis): Redis 클라이언트 인스턴스
+
     Returns:
         List[dict]: 미팅룸 목록
     """
     try:
-        return await get_all_meeting_rooms()
+        return await get_all_meeting_rooms(redis)
 
     except Exception as e:
+        print(e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Redis에서 미팅룸 조회 중 오류가 발생했습니다.",
@@ -59,7 +70,7 @@ async def get_meeting_rooms():
 
 
 @meetings_router.post("/join", response_model=dict, status_code=status.HTTP_201_CREATED)
-async def join_meeting_room(request: RoomJoin):
+async def join_meeting_room(request: RoomJoin, redis: Redis = Depends(get_redis)):
     """
     미팅룸 입장을 Redis에서 수행하는 엔드포인트입니다.
 
@@ -67,15 +78,17 @@ async def join_meeting_room(request: RoomJoin):
 
     Args:
         request (RoomJoin): 클라이언트와 미팅룸 ID 정보
+        redis (Redis): Redis 클라이언트 인스턴스
 
     Returns:
         dict: 성공 메시지
     """
     try:
-        await add_to_meeting_room(request.room_id, None, request.client_id)
+        await add_to_meeting_room(redis, request.room_id, None, request.client_id)
         return {"message": "미팅룸 입장 성공"}
 
     except Exception as e:
+        print(e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Redis에서 미팅룸 입장 처리 중 오류가 발생했습니다.",
@@ -85,7 +98,7 @@ async def join_meeting_room(request: RoomJoin):
 @meetings_router.post(
     "/leave", response_model=dict, status_code=status.HTTP_201_CREATED
 )
-async def leave_meeting_room(request: RoomLeave):
+async def leave_meeting_room(request: RoomLeave, redis: Redis = Depends(get_redis)):
     """
     미팅룸 퇴장을 Redis에서 수행하는 엔드포인트입니다.
 
@@ -93,15 +106,17 @@ async def leave_meeting_room(request: RoomLeave):
 
     Args:
         request (RoomLeave): 클라이언트와 미팅룸 ID 정보
+        redis (Redis): Redis 클라이언트 인스턴스
 
     Returns:
         dict: 성공 메시지
     """
     try:
-        await remove_from_meeting_room(request.room_id, request.client_id)
+        await remove_from_meeting_room(redis, request.room_id, request.client_id)
         return {"message": "미팅룸 퇴장 성공"}
 
     except Exception as e:
+        print(e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Redis에서 미팅룸 퇴장 처리 중 오류가 발생했습니다.",


### PR DESCRIPTION
Redis 관련 기능 개선을 위한 meetings.py 파일의 수정사항:

1. Redis 클라이언트 의존성 변경
- redis 패키지에서 redis.asyncio로 변경하여 비동기 지원
- Redis 클라이언트를 FastAPI의 Depends를 통해 주입하도록 수정

2. 엔드포인트 함수 시그니처 수정
- 모든 엔드포인트에 Redis 클라이언트 파라미터 추가
- 각 함수의 docstring에 Redis 파라미터 설명 추가

3. CRUD 함수 호출 수정
- add_to_meeting_room, remove_from_meeting_room, get_all_meeting_rooms 함수 호출 시 Redis 클라이언트 전달하도록 수정

4. 에러 처리 개선
- 예외 발생 시 로깅을 위한 print(e) 추가

이 변경으로 'str' object has no attribute 'hset' 에러가 해결되며, Redis 작업의 비동기 처리가 올바르게 동작하도록 개선되었습니다.